### PR TITLE
📝 PostgreSQL Persistence Implementation (Reactive with R2DBC)

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+	implementation project(':r2dbc-postgresql')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'
@@ -23,4 +25,3 @@ bootJar {
     // Sets output jar name
     archiveFileName = "${project.getParent().getName()}.${archiveExtension.get()}"
 }
-

--- a/applications/app-service/src/main/java/co/com/powerup/crediya/santiagomh04/msvc-authentication/config/ObjectMapperConfig.java
+++ b/applications/app-service/src/main/java/co/com/powerup/crediya/santiagomh04/msvc-authentication/config/ObjectMapperConfig.java
@@ -1,0 +1,16 @@
+package co.com.powerup.crediya.santiagomh04.msvc-authentication.config;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapperImp();
+    }
+
+}

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -12,3 +12,12 @@ spring:
       path: /h2
   profiles:
     include:
+
+adapters:
+  r2dbc:
+    host: "localhost"
+    port: 5432
+    database: "crediya_db"
+    schema: "public"
+    username: "postgres"
+    password: "sasa"

--- a/applications/app-service/src/test/java/co/com/powerup/crediya/santiagomh04/msvc-authentication/config/ObjectMapperConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/powerup/crediya/santiagomh04/msvc-authentication/config/ObjectMapperConfigTest.java
@@ -1,0 +1,20 @@
+package co.com.powerup.crediya.santiagomh04.msvc-authentication.config;
+
+import org.junit.jupiter.api.Test;
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObjectMapperConfigTest {
+
+    @Test
+    void testObjectMapperBean() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ObjectMapperConfig.class);
+        ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
+        assertNotNull(objectMapper);
+        assertTrue(objectMapper instanceof ObjectMapperImp);
+        context.close();
+    }
+}

--- a/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/model/role/Role.java
+++ b/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/model/role/Role.java
@@ -12,14 +12,14 @@ public class Role {
     ROLE_AGENT(2L, "ROLE_AGENT", "Represents a user who manages applicants."),
     ROLE_ADMIN(3L, "ROLE_ADMIN", "Represents a user with full administrative privileges.");*/
 
+    private Long id;
+    private String name;
+      /*private RoleName name;*/
+    private String description;
+
     public enum RoleName{
         ROLE_APPLICANT,
         ROLE_AGENT,
         ROLE_ADMIN;
     }
-
-    private Long id;
-    private String name;
-        /*private RoleName name;*/
-    private String description;
 }

--- a/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/model/role/gateways/RoleRepository.java
+++ b/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/model/role/gateways/RoleRepository.java
@@ -5,6 +5,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface RoleRepository {
+    Mono<Role> findById(Long id);
     Mono<Role> findByName(String name);
     Flux<Role> findAll();
 }

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/IUserUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/IUserUseCase.java
@@ -18,6 +18,7 @@ public class IUserUseCase implements UserUseCase{
     @Override
     public Mono<User> createUser(User user) {
         return this.userValidator.validateUser(user)
+                // Assign ROLE_APPLICANT by default
             .then(this.repoRole.findByName(Role.RoleName.ROLE_APPLICANT.name()))
             .flatMap(role -> {
                 user.setRole(role);

--- a/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'jakarta.persistence:jakarta.persistence-api' // TODO: Check if it's still necessary
+    implementation 'org.postgresql:r2dbc-postgresql'
+    implementation 'org.reactivecommons.utils:object-mapper-api:0.1.0'
+
+    testImplementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+}
+

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/MyReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/MyReactiveRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.adapters;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.helper.ReactiveAdapterOperations;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.repositories.MyReactiveRepository;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MyReactiveRepositoryAdapter extends ReactiveAdapterOperations<
+    Object/* change for domain model */,
+    Object/* change for adapter model */,
+    String,
+        MyReactiveRepository
+> {
+    public MyReactiveRepositoryAdapter(MyReactiveRepository repository, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/RoleReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/RoleReactiveRepositoryAdapter.java
@@ -1,0 +1,36 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.adapters;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.role.Role;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.role.gateways.RoleRepository;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.mapper.RoleMapper;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.repositories.RoleReactiveRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+@RequiredArgsConstructor
+public class RoleReactiveRepositoryAdapter implements RoleRepository {
+
+    private final RoleReactiveRepository repoRoleReactive;
+    private final RoleMapper roleMapper;
+
+    @Override
+    public Mono<Role> findById(Long id) {
+        return this.repoRoleReactive.findById(id)
+            .map(this.roleMapper::toDomain);
+    }
+
+    @Override
+    public Mono<Role> findByName(String name) {
+        return this.repoRoleReactive.findByName(name)
+            .map(this.roleMapper::toDomain);
+    }
+
+    @Override
+    public Flux<Role> findAll() {
+        return this.repoRoleReactive.findAll()
+            .map(this.roleMapper::toDomain);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/UserReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/UserReactiveRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.adapters;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.user.User;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.user.gateways.UserRepository;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.mapper.UserMapper;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.repositories.UserReactiveRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+@Repository
+@RequiredArgsConstructor
+public class UserReactiveRepositoryAdapter implements UserRepository {
+
+    private final UserReactiveRepository repoUserReactive;
+    private final UserMapper userMapper;
+
+    @Override
+    public Mono<User> save(User user) {
+        return this.repoUserReactive.save(this.userMapper.toEntity(user))
+            .flatMap(userMapper::toDomain);
+    }
+
+    @Override
+    public Mono<Boolean> existsByEmail(String email) {
+        return this.repoUserReactive.existsByEmail(email);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/config/PostgreSQLConnectionPool.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/config/PostgreSQLConnectionPool.java
@@ -1,0 +1,44 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.config
+
+-authentication.r2dbc.config;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class PostgreSQLConnectionPool {
+    /* Change these values for your project */
+    public static final int INITIAL_SIZE = 12;
+    public static final int MAX_SIZE = 15;
+    public static final int MAX_IDLE_TIME = 30;
+    public static final int DEFAULT_PORT = 5432;
+
+	@Bean
+	public ConnectionPool getConnectionConfig(PostgreSQLConnectionProperties properties) {
+		PostgresqlConnectionConfiguration dbConfiguration = PostgresqlConnectionConfiguration.builder()
+                .host(properties.host())
+                .port(properties.port())
+                .database(properties.database())
+                .schema(properties.schema())
+                .username(properties.username())
+                .password(properties.password())
+                .build();
+
+        ConnectionPoolConfiguration poolConfiguration = ConnectionPoolConfiguration.builder()
+                .connectionFactory(new PostgresqlConnectionFactory(dbConfiguration))
+                .name("api-postgres-connection-pool")
+                .initialSize(INITIAL_SIZE)
+                .maxSize(MAX_SIZE)
+                .maxIdleTime(Duration.ofMinutes(MAX_IDLE_TIME))
+                .validationQuery("SELECT 1")
+                .build();
+
+		return new ConnectionPool(poolConfiguration);
+	}
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/config/PostgreSQLConnectionProperties.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/config/PostgreSQLConnectionProperties.java
@@ -1,0 +1,14 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.config;
+
+// TODO: Load properties from the application.yaml file or from secrets manager
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "adapters.r2dbc")
+public record PostgreSQLConnectionProperties(
+    String host,
+    Integer port,
+    String database,
+    String schema,
+    String username,
+    String password) {
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/entities/RoleEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/entities/RoleEntity.java
@@ -1,0 +1,31 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table("roles")
+public class RoleEntity {
+    @Id
+    private Long id;
+
+    @Column("name")
+    private String name;
+
+    @Column("description")
+    private String description;
+
+    public enum RoleName{
+        ROLE_APPLICANT,
+        ROLE_AGENT,
+        ROLE_ADMIN;
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/entities/UserEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/entities/UserEntity.java
@@ -1,0 +1,63 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table("users")
+public class UserEntity {
+    @Id
+    private String id;
+
+    @Column("name")
+    private String name;
+
+    @Column("last_name")
+    private String lastName;
+
+    @Column("address")
+    private String address;
+
+    @Column("telephone")
+    private String telephone;
+
+    @Column("date_of_birth")
+    private LocalDate dateOfBirth;
+
+    @Column("base_salary")
+    private BigInteger baseSalary;
+
+    @Column("document_type")
+    private DocumentType documentType;
+
+    @Column("identification_number")
+    private String identificationNumber;
+
+    @Column("email")
+    private String email;
+
+    @Column("password")
+    private String password;
+
+    @Column("role_id")
+    private Long roleId;
+
+    public enum DocumentType{
+        CC,
+        CE,
+        DNI,
+        PASSPORT,
+        OTHER;
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/helper/ReactiveAdapterOperations.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/helper/ReactiveAdapterOperations.java
@@ -1,0 +1,67 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+public abstract class ReactiveAdapterOperations<E, D, I, R extends ReactiveCrudRepository<D, I> & ReactiveQueryByExampleExecutor<D>> {
+    protected R repository;
+    protected ObjectMapper mapper;
+    private final Class<D> dataClass;
+    private final Function<D, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    protected ReactiveAdapterOperations(R repository, ObjectMapper mapper, Function<D, E> toEntityFn) {
+        this.repository = repository;
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<D>) genericSuperclass.getActualTypeArguments()[1];
+        this.toEntityFn = toEntityFn;
+    }
+
+    protected D toData(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(D data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+    public Mono<E> save(E entity) {
+        return saveData(toData(entity))
+                .map(this::toEntity);
+    }
+
+    protected Flux<E> saveAllEntities(Flux<E> entities) {
+        return saveData(entities.map(this::toData))
+                .map(this::toEntity);
+    }
+
+    protected Mono<D> saveData(D data) {
+        return repository.save(data);
+    }
+
+    protected Flux<D> saveData(Flux<D> data) {
+        return repository.saveAll(data);
+    }
+
+    public Mono<E> findById(I id) {
+        return repository.findById(id).map(this::toEntity);
+    }
+
+    public Flux<E> findByExample(E entity) {
+        return repository.findAll(Example.of(toData(entity)))
+                .map(this::toEntity);
+    }
+
+    public Flux<E> findAll() {
+        return repository.findAll()
+                .map(this::toEntity);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/mapper/RoleMapper.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/mapper/RoleMapper.java
@@ -1,0 +1,23 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.mapper;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.role.Role;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.entities.RoleEntity;
+import lombok.RequiredArgsConstructor;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoleMapper {
+
+    private final ObjectMapper objectMapper;
+
+    public Role toDomain(RoleEntity roleEntity) {
+        return this.objectMapper.map(roleEntity, Role.class);
+    }
+
+    public RoleEntity toEntity(Role role) {
+        return this.objectMapper.map(role, RoleEntity.class);
+    }
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/mapper/UserMapper.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/mapper/UserMapper.java
@@ -1,0 +1,39 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.mapper;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.role.Role;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.role.gateways.RoleRepository;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.user.User;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.entities.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class UserMapper {
+
+    private final ObjectMapper objectMapper;
+    private final RoleRepository roleRepository;
+
+    public Mono<User> toDomain(UserEntity userEntity){
+        User user = this.objectMapper.map(userEntity, User.class);
+
+        return this.roleRepository.findById(userEntity.getRoleId())
+            .flatMap(roleEntity -> {
+                Role role = objectMapper.map(roleEntity, Role.class);
+                user.setRole(role);
+                return Mono.just(user);
+            });
+    }
+
+    public UserEntity toEntity(User user) {
+        UserEntity userEntity = this.objectMapper.map(user, UserEntity.class);
+
+        if (user.getRole() != null) {
+            userEntity.setRoleId(user.getRole().getId());
+        }
+
+        return userEntity;
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/MyReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/MyReactiveRepository.java
@@ -1,0 +1,9 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.repositories;
+
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+// TODO: This file is just an example, you should delete or modify it
+public interface MyReactiveRepository extends ReactiveCrudRepository<Object, String>, ReactiveQueryByExampleExecutor<Object> {
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/RoleReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/RoleReactiveRepository.java
@@ -1,0 +1,10 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.repositories;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.entities.RoleEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface RoleReactiveRepository extends ReactiveCrudRepository<RoleEntity, Long> {
+    Mono<RoleEntity> findByName(String name);
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/UserReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/UserReactiveRepository.java
@@ -1,0 +1,9 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.repositories;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.entities.UserEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface UserReactiveRepository extends ReactiveCrudRepository<UserEntity, String> {
+    Mono<Boolean> existsByEmail(String email);
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/MyReactiveRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/MyReactiveRepositoryAdapterTest.java
@@ -1,0 +1,82 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc
+
+-authentication.r2dbc;
+
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.repositories.MyReactiveRepository;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.adapters.MyReactiveRepositoryAdapter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MyReactiveRepositoryAdapterTest {
+    // TODO: change four you own tests
+
+    @InjectMocks
+    MyReactiveRepositoryAdapter repositoryAdapter;
+
+    @Mock
+    MyReactiveRepository repository;
+
+    @Mock
+    ObjectMapper mapper;
+
+    @Test
+    void mustFindValueById() {
+
+        when(repository.findById("1")).thenReturn(Mono.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Mono<Object> result = repositoryAdapter.findById("1");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustFindAllValues() {
+        when(repository.findAll()).thenReturn(Flux.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Flux<Object> result = repositoryAdapter.findAll();
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustFindByExample() {
+        when(repository.findAll(any(Example.class))).thenReturn(Flux.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Flux<Object> result = repositoryAdapter.findByExample("test");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustSaveValue() {
+        when(repository.save("test")).thenReturn(Mono.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Mono<Object> result = repositoryAdapter.save("test");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/config/PostgreSQLConnectionPoolTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/config/PostgreSQLConnectionPoolTest.java
@@ -1,0 +1,39 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.config
+
+-authentication.r2dbc.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+class PostgreSQLConnectionPoolTest {
+
+    @InjectMocks
+    private PostgreSQLConnectionPool connectionPool;
+
+    @Mock
+    private PostgreSQLConnectionProperties properties;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(properties.host()).thenReturn("localhost");
+        when(properties.port()).thenReturn(5432);
+        when(properties.database()).thenReturn("dbName");
+        when(properties.schema()).thenReturn("schema");
+        when(properties.username()).thenReturn("username");
+        when(properties.password()).thenReturn("password");
+    }
+
+    @Test
+    void getConnectionConfigSuccess() {
+        assertNotNull(connectionPool.getConnectionConfig(properties));
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/helper/ReactiveAdapterOperationsTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/helper/ReactiveAdapterOperationsTest.java
@@ -1,0 +1,170 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.r2dbc.helper
+
+-authentication.r2dbc.helper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ReactiveAdapterOperationsTest {
+
+    private DummyRepository repository;
+    private ObjectMapper mapper;
+    private ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository> operations;
+
+    @BeforeEach
+    void setUp() {
+        repository = Mockito.mock(DummyRepository.class);
+        mapper = Mockito.mock(ObjectMapper.class);
+        operations = new ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository>(
+                repository, mapper, DummyEntity::toEntity) {};
+    }
+
+    @Test
+    void save() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.save(data)).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.save(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void saveAllEntities() {
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+
+        when(mapper.map(entity1, DummyData.class)).thenReturn(data1);
+        when(mapper.map(entity2, DummyData.class)).thenReturn(data2);
+        when(repository.saveAll(any(Flux.class))).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.saveAllEntities(Flux.just(entity1, entity2)))
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    @Test
+    void findById() {
+        DummyData data = new DummyData("1", "test");
+        DummyEntity entity = new DummyEntity("1", "test");
+
+        when(repository.findById("1")).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.findById("1"))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findByExample() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.findAll(any(Example.class))).thenReturn(Flux.just(data));
+
+        StepVerifier.create(operations.findByExample(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findAll() {
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+
+        when(repository.findAll()).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.findAll())
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    static class DummyEntity {
+        private String id;
+        private String name;
+
+        public DummyEntity(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public static DummyEntity toEntity(DummyData data) {
+            return new DummyEntity(data.getId(), data.getName());
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyEntity that = (DummyEntity) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    static class DummyData {
+        private String id;
+        private String name;
+
+        public DummyData(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyData that = (DummyData) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    interface DummyRepository extends ReactiveCrudRepository<DummyData, String>, ReactiveQueryByExampleExecutor<DummyData> {}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,5 @@ include ':usecase'
 project(':app-service').projectDir = file('./applications/app-service')
 project(':model').projectDir = file('./domain/model')
 project(':usecase').projectDir = file('./domain/usecase')
+include ':r2dbc-postgresql'
+project(':r2dbc-postgresql').projectDir = file('./infrastructure/driven-adapters/r2dbc-postgresql')


### PR DESCRIPTION
The persistence layer was implemented to support the storage and retrieval of domain entities using PostgreSQL with a fully reactive stack via R2DBC. The following tasks were completed:

🏗️ Persistence classes created:

Defined reactive data entities to represent and map domain models to PostgreSQL tables.

🔄 Reactive mapping between layers:

- Implemented bi-directional mappers to transform between persistence models and domain entities in a non-blocking, reactive manner.

🧩 Domain repository implementations:

- Developed reactive implementations of the domain-layer repositories using R2DBC, enabling non-blocking data access.
- Ensured strict adherence to clean architecture principles, maintaining separation of concerns and avoiding domain-infrastructure coupling.

This implementation establishes a solid and scalable foundation for reactive data persistence, enabling efficient integration with WebFlux-based services and supporting high-throughput, non-blocking operations.