### PR TITLE
HU2/feature: user searching by identification number validation

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -29,6 +29,7 @@ routes:
   paths:
     users: "api/v1/users"
     userById: "api/v1/users/{id}"
+    userByIdentificationNumber: "api/v1/users/{identificationNumber}"
 
   #PostgreSQL
 adapters:

--- a/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/exceptions/business/InternalCauses.java
+++ b/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/exceptions/business/InternalCauses.java
@@ -1,0 +1,12 @@
+package co.com.powerup.crediya.santiagomh04.msvcauthentication.exceptions.business;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InternalCauses {
+    USER_NOT_FOUND("the user you’re searching is not registered in our system");
+
+    private final String message;
+}

--- a/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/model/user/gateways/UserRepository.java
+++ b/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/model/user/gateways/UserRepository.java
@@ -5,6 +5,7 @@ import reactor.core.publisher.Mono;
 
 public interface UserRepository {
     Mono<User> save(User user);
+    Mono<User> findByIdentificationNumber(String identificationNumber);
     Mono<Boolean> existsByEmail(String email);
 }
 

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/IUserUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/IUserUseCase.java
@@ -27,6 +27,11 @@ public class IUserUseCase implements UserUseCase{
     }
 
     @Override
+    public Mono<User> findByIdentificationNumber(String identificationNumber) {
+        return this.repoUser.findByIdentificationNumber(identificationNumber);
+    }
+
+    @Override
     public Mono<Boolean> existsByEmail(String email) {
         return this.repoUser.existsByEmail(email);
     }

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/IUserUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/IUserUseCase.java
@@ -28,7 +28,7 @@ public class IUserUseCase implements UserUseCase{
 
     @Override
     public Mono<User> findByIdentificationNumber(String identificationNumber) {
-        return this.repoUser.findByIdentificationNumber(identificationNumber);
+        return this.userValidator.validateUserSearch(identificationNumber);
     }
 
     @Override

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/UserUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/UserUseCase.java
@@ -5,5 +5,6 @@ import reactor.core.publisher.Mono;
 
 public interface UserUseCase {
     Mono<User> createUser(User user);
+    Mono<User> findByIdentificationNumber(String identificationNumber);
     Mono<Boolean> existsByEmail(String email);
 }

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/validations/UserValidator.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/validations/UserValidator.java
@@ -1,5 +1,7 @@
 package co.com.powerup.crediya.santiagomh04.msvcauthentication.usecase.user.validations;
 
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.exceptions.business.BusinessException;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.exceptions.business.InternalCauses;
 import co.com.powerup.crediya.santiagomh04.msvcauthentication.exceptions.validation.ErrorCauses;
 import co.com.powerup.crediya.santiagomh04.msvcauthentication.exceptions.validation.ValidationException;
 import co.com.powerup.crediya.santiagomh04.msvcauthentication.model.user.User;
@@ -35,6 +37,12 @@ public class UserValidator {
             .then(Mono.defer(() -> validateAge(user.getDateOfBirth())))
             .then(Mono.defer(() -> validateSalaryRange(user.getBaseSalary())));
     }
+
+    public Mono<User> validateUserSearch(String identificationNumber) {
+        return this.repoUser.findByIdentificationNumber(identificationNumber)
+            .switchIfEmpty(Mono.error(new BusinessException(InternalCauses.USER_NOT_FOUND.getMessage())));
+    }
+
 
     //1. Required fields validation
     private Mono<Void> validateRequiredFields(User user) {

--- a/domain/usecase/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/validations/UserValidatorTest.java
+++ b/domain/usecase/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/usecase/user/validations/UserValidatorTest.java
@@ -126,7 +126,7 @@ class UserValidatorTest {
         StepVerifier.create(this.userValidator.validateUser(this.user))
             .verifyErrorMatches(throwable ->
                 throwable instanceof ValidationException &&
-                        throwable.getMessage().contains("must be at least 18 years old")
+                    throwable.getMessage().contains("must be at least 18 years old")
             );
     }
 

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/UserReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/adapters/UserReactiveRepositoryAdapter.java
@@ -18,7 +18,13 @@ public class UserReactiveRepositoryAdapter implements UserRepository {
     @Override
     public Mono<User> save(User user) {
         return this.repoUserReactive.save(this.userMapper.toEntity(user))
-            .flatMap(userMapper::toDomain);
+            .flatMap(this.userMapper::toDomain);
+    }
+
+    @Override
+    public Mono<User> findByIdentificationNumber(String identificationNumber) {
+        return this.repoUserReactive.findByIdentificationNumber(identificationNumber)
+            .flatMap(this.userMapper::toDomain);
     }
 
     @Override

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/UserReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/r2dbc/repositories/UserReactiveRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 public interface UserReactiveRepository extends ReactiveCrudRepository<UserEntity, String> {
+    Mono<UserEntity> findByIdentificationNumber(String identificationNumber);
     Mono<Boolean> existsByEmail(String email);
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/RouterRest.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
@@ -67,7 +68,8 @@ public class RouterRest {
         /*@RouterOperation()*/
     })
     public RouterFunction<ServerResponse> routerFunction() {
-        return route(POST(this.userPaths.getUsers()), this.userHandler::listenPOSTUseCase);
+        return route(POST(this.userPaths.getUsers()), this.userHandler::listenPOSTUseCase)
+            .andRoute(GET(this.userPaths.getUserByIdentificationNumber()), this.userHandler::listenGETUseCase);
 
         /*return route(GET("/api/usecase/path"), handler::listenGETUseCase)
             .andRoute(POST("/api/usecase/otherpath"), handler::listenPOSTUseCase)

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/RouterRest.java
@@ -65,6 +65,31 @@ public class RouterRest {
                 }
             )
         ),
+        @RouterOperation(
+            path = "/api/v1/users/{identificationNumber}",
+            produces = {MediaType.APPLICATION_JSON_VALUE},
+            method = RequestMethod.GET,
+            beanClass = UserAPIHandler.class,
+            beanMethod = "listenGETUseCase",
+            operation = @Operation(
+                operationId = "searchUser",
+                summary = "Searches for an already registered user",
+                description = "Registers a new user with the information provided.",
+                tags = {"User"},
+                responses = {
+                    @ApiResponse(
+                        responseCode = "200",
+                        description = "User found successfully",
+                        content = @Content(schema = @Schema(implementation = UserResponseDTO.class))
+                    ),
+                    @ApiResponse(
+                        responseCode = "404",
+                        description = "User not found",
+                        content = @Content(schema = @Schema(implementation = ErrorResponseDTO.class))
+                    )
+                }
+            )
+        )
         /*@RouterOperation()*/
     })
     public RouterFunction<ServerResponse> routerFunction() {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/handlers/apiHandler/UserAPIHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/handlers/apiHandler/UserAPIHandler.java
@@ -27,9 +27,10 @@ public class UserAPIHandler {
             .map(String::trim)
             .filter(item -> !item.isBlank())
             .flatMap(this.userUseCase::findByIdentificationNumber)
-            .flatMap(user -> ServerResponse.ok()
+            .map(this.userApiMapper::toResponse)
+            .flatMap(dto -> ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(user)
+                .bodyValue(dto)
             );
     }
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/handlers/exceptionHandler/GlobalExceptionHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/handlers/exceptionHandler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package co.com.powerup.crediya.santiagomh04.msvcauthentication.api.handlers.exceptionHandler;
 
 import co.com.powerup.crediya.santiagomh04.msvcauthentication.api.handlers.loggingHelpers.HandlerLoggingSupport;
+import co.com.powerup.crediya.santiagomh04.msvcauthentication.exceptions.business.BusinessException;
 import co.com.powerup.crediya.santiagomh04.msvcauthentication.exceptions.validation.ValidationException;
 import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
@@ -21,8 +22,9 @@ public class GlobalExceptionHandler extends AbstractErrorWebExceptionHandler {
 
     private final HandlerLoggingSupport loggingSupport;
 
-    private static final Map<Class<? extends Throwable>, HttpStatus> EXCEPTION_STATUS_MAP = Map.of(
-        ValidationException.class, HttpStatus.BAD_REQUEST
+    private static final Map<Class<? extends Throwable>, HttpStatus> EXCEPTION_STATUS_MAP = Map.ofEntries(
+        Map.entry(ValidationException.class, HttpStatus.BAD_REQUEST),
+        Map.entry(BusinessException.class, HttpStatus.NOT_FOUND)
         // Add more exceptions here and their HttpStatus codes when necessary
     );
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/handlers/loggingHelpers/HandlerLoggingSupport.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/handlers/loggingHelpers/HandlerLoggingSupport.java
@@ -61,7 +61,7 @@ public class HandlerLoggingSupport {
             LocalDateTime.now(),
             request.path(),
             error.getMessage(),
-            status.toString()
+            status.toString().toLowerCase().replaceAll("_", " ")
         );
 
         return ServerResponse.status(status.value())

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/paths/UserPaths.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/paths/UserPaths.java
@@ -10,4 +10,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class UserPaths {
     private String users;
     private String userById;
+    private String userByIdentificationNumber;
 }

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/config/RouterTestConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/powerup/crediya/santiagomh04/msvcauthentication/api/config/RouterTestConfig.java
@@ -39,7 +39,8 @@ public class RouterTestConfig {
     @Bean
     public UserPaths userPaths() {
         UserPaths mockUserPaths = mock(UserPaths.class);
-        when(mockUserPaths.getUsers()).thenReturn("/api/v1/users");
+            when(mockUserPaths.getUsers()).thenReturn("/api/v1/users");
+            when(mockUserPaths.getUserByIdentificationNumber()).thenReturn("/api/v1/users/{identificationNumber}");
         return mockUserPaths;
     }
 


### PR DESCRIPTION
This pull request introduces and consolidates the `findByIdentificationNumber()` functionality across the service, ensuring architectural clarity, proper error handling, and full test coverage.

**🔹 Domain Layer**
- Added the `findByIdentificationNumber()` use case in the domain service, delegating responsibility to the UserValidator.
- The validator now encapsulates the repository call and enforces business rules:
- Returns the User when found.
- Throws a BusinessException with a mapped cause when the user does not exist.
- This design keeps the domain logic clean, handler‑agnostic, and reusable across other flows (e.g., loan creation).

🔹 Infrastructure Layer
- Integrated the repository query (findByIdentificationNumber) with reactive support.
- Centralised exception mapping through EXCEPTION_STATUS_MAP, ensuring consistent translation of domain exceptions into HTTP status codes (e.g., BusinessException → 404 Not Found, ValidationException → 400 Bad Request).
- Router configuration updated to expose the GET endpoint:
`GET /api/v1/users/{identificationNumber}` which delegates to the UserHandler.listenGETUseCase.

**🔹 Documentation**
- Documented the architectural decision to delegate all validation and error mapping to the validator and centralised support classes.
- Clarified the distinction between business errors (mapped to 4xx) and unexpected failures (mapped to 5xx).
- Updated API contract to reflect the new GET endpoint and its possible responses (200 OK, 404 Not Found, 400 Bad Request).

**🔹 Unit Tests**
- Domain tests: verified that the validator returns the expected User or raises BusinessException when not found.
- Use case tests: confirmed delegation from findByUserIdentification() to the validator.
- Router tests:
- Happy path → 200 OK with the expected UserResponseDTO.
- Ensured tests follow Arrange → Act → Assert, with clear verification of delegation and response contracts.

✅ With these changes, the service now provides a robust, well‑documented, and fully tested `findByIdentificationNumber()` flow, aligned with our principles of encapsulation, centralised error handling, and clean separation of concerns.